### PR TITLE
Replace writer for CSV output

### DIFF
--- a/src/main/java/org/opendatakit/suitcase/net/DownloadTask.java
+++ b/src/main/java/org/opendatakit/suitcase/net/DownloadTask.java
@@ -12,8 +12,10 @@ import org.opendatakit.suitcase.ui.ProgressBarStatus;
 import org.opendatakit.suitcase.ui.SuitcaseProgressBar;
 import org.opendatakit.suitcase.utils.FileUtils;
 
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.ExecutionException;
 
 import static org.opendatakit.suitcase.ui.MessageString.*;
@@ -72,8 +74,11 @@ public class DownloadTask extends SuitcaseSwingWorker<Void> {
     publish(new ProgressBarStatus(0, PROCESSING_ROW, false));
     RFC4180CsvWriter csvWriter = null;
     try {
-      csvWriter = new RFC4180CsvWriter(new FileWriter(
-          FileUtils.getCSVPath(cloudEndpointInfo, csv.getTableId(), csvConfig, savePath).toString()
+      csvWriter = new RFC4180CsvWriter(Files.newBufferedWriter(
+          FileUtils.getCSVPath(cloudEndpointInfo, csv.getTableId(), csvConfig, savePath),
+          StandardCharsets.UTF_8,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING
       ));
 
       //Write header then rows


### PR DESCRIPTION
CSV output should not be written with the system default encoding. Using the system default encoding produces inconsistent CSV output. 

The changes replace the currently used `FileWriter` with a `Writer` that uses the `UTF-8` encoding. 

This issue was reported by Caroline on [https://forum.opendatakit.org/t/suitcase-downloading-to-pc-with-utf-8]().